### PR TITLE
fix pocketflow-workflow yaml parse error

### DIFF
--- a/cookbook/pocketflow-workflow/nodes.py
+++ b/cookbook/pocketflow-workflow/nodes.py
@@ -1,3 +1,4 @@
+import re
 from pocketflow import Node, BatchNode
 from utils import call_llm
 import yaml
@@ -21,6 +22,11 @@ sections:
 ```"""
         response = call_llm(prompt)
         yaml_str = response.split("```yaml")[1].split("```")[0].strip()
+        yaml_str = re.sub(
+            r'(?m)^(\s*)-\s*([^"\n]+)',
+            r'\1- "\2"',
+            yaml_str
+        )
         structured_result = yaml.safe_load(yaml_str)
         return structured_result
     


### PR DESCRIPTION
Use re to handle the unexpected conversion of colons in the yaml format
In the workflow file of the cookbook, I found that GenerateOutline might produce the following result:
sections: 
  - Introduction to AI Safety: Understanding the Importance and Challenges 
  - Current Approaches and Strategies in AI Safety Research 
  - Future Directions and Collaborative Efforts for Safe AI Development

after yaml safe_load

The value of structured_result is:

{
  "sections": [
    {
      "Introduction to AI Safety": "Understanding the Importance and Challenges"
    },
    "Current Approaches and Strategies in AI Safety Research",
    "Future Directions and Collaborative Efforts for Safe AI Development"
  ]
}


Finally, the following error is caused：
 line 71, in exec
    section_contents[section] = content
    ~~~~~~~~~~~~~~~~^^^^^^^^^
TypeError: unhashable type: 'dict'


I corrected the results with a regular expression, hoping it would help the project。
