### PR TITLE
update the llm wrappers example for google ai / gemini

### DIFF
--- a/docs/utility_function/llm.md
+++ b/docs/utility_function/llm.md
@@ -45,13 +45,13 @@ Here, we provide some minimal example implementations:
 3. Google (Generative AI Studio / PaLM API)
     ```python
     def call_llm(prompt):
-        import google.generativeai as genai
-        genai.configure(api_key="YOUR_API_KEY_HERE")
-        r = genai.generate_text(
-            model="models/text-bison-001",
-            prompt=prompt
-        )
-        return r.result
+    from google import genai
+    client = genai.Client(api_key='GEMINI_API_KEY')
+        response = client.models.generate_content(
+        model='gemini-2.0-flash-001',
+        contents=prompt
+    )
+    return response.text
     ```
 
 4. Azure (Azure OpenAI)


### PR DESCRIPTION
The existing code for the wrapper class of Google was outdated, so I found the updated version from the official repository at

 [https://github.com/googleapis/python-genai ](https://github.com/googleapis/python-genai).

 To use the updated package, install it using the following command:

```
pip install google-genai
```