### PR TITLE
pocketflow-agent add search_web_brave

### DIFF
--- a/cookbook/pocketflow-agent/nodes.py
+++ b/cookbook/pocketflow-agent/nodes.py
@@ -1,5 +1,5 @@
 from pocketflow import Node
-from utils import call_llm, search_web
+from utils import call_llm, search_web_duckduckgo
 import yaml
 
 class DecideAction(Node):
@@ -85,7 +85,7 @@ class SearchWeb(Node):
         """Search the web for the given query."""
         # Call the search utility function
         print(f"🌐 Searching the web for: {search_query}")
-        results = search_web(search_query)
+        results = search_web_duckduckgo(search_query)
         return results
     
     def post(self, shared, prep_res, exec_res):

--- a/cookbook/pocketflow-agent/requirements.txt
+++ b/cookbook/pocketflow-agent/requirements.txt
@@ -2,3 +2,4 @@ pocketflow>=0.0.1
 aiohttp>=3.8.0  # For HTTP requests
 openai>=1.0.0   # For LLM calls 
 duckduckgo-search>=7.5.2    # For web search
+requests>=2.25.1  # For HTTP requests

--- a/cookbook/pocketflow-agent/utils.py
+++ b/cookbook/pocketflow-agent/utils.py
@@ -1,6 +1,7 @@
 from openai import OpenAI
 import os
 from duckduckgo_search import DDGS
+import requests
 
 def call_llm(prompt):    
     client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY", "your-api-key"))
@@ -10,10 +11,31 @@ def call_llm(prompt):
     )
     return r.choices[0].message.content
 
-def search_web(query):
+def search_web_duckduckgo(query):
     results = DDGS().text(query, max_results=5)
     # Convert results to a string
     results_str = "\n\n".join([f"Title: {r['title']}\nURL: {r['href']}\nSnippet: {r['body']}" for r in results])
+    return results_str
+
+def search_web_brave(query):
+
+    url = f"https://api.search.brave.com/res/v1/web/search?q={query}"
+    api_key = "your brave search api key"
+
+    headers = {
+        "accept": "application/json",
+        "Accept-Encoding": "gzip",
+        "x-subscription-token": api_key
+    }
+
+    response = requests.get(url, headers=headers)
+
+    if response.status_code == 200:
+        data = response.json()
+        results = data['web']['results']
+        results_str = "\n\n".join([f"Title: {r['title']}\nURL: {r['url']}\nDescription: {r['description']}" for r in results])     
+    else:
+        print(f"Request failed with status code: {response.status_code}")
     return results_str
     
 if __name__ == "__main__":


### PR DESCRIPTION
Thank you for open-sourcing PocketFlow, I have learned a lot from it. 
While studying the pocketflow-agent, I tried to improve the web search functionality. The free subscription to Brave Search provides a quota of 2,000 requests per month, and its performance is slightly better than DuckDuckGo. I am considering adding a search_web_brave option to offer more choices, but the default would still be search_web_duckduckgo. Do you think this is feasible?