### PR TITLE
Fix AsyncNode retry mechanism to use self.cur_retry attribute

### DIFF
--- a/pocketflow/__init__.py
+++ b/pocketflow/__init__.py
@@ -62,10 +62,10 @@ class AsyncNode(Node):
     async def exec_fallback_async(self,prep_res,exc): raise exc
     async def post_async(self,shared,prep_res,exec_res): pass
     async def _exec(self,prep_res): 
-        for i in range(self.max_retries):
+        for self.cur_retry in range(self.max_retries):
             try: return await self.exec_async(prep_res)
             except Exception as e:
-                if i==self.max_retries-1: return await self.exec_fallback_async(prep_res,e)
+                if self.cur_retry==self.max_retries-1: return await self.exec_fallback_async(prep_res,e)
                 if self.wait>0: await asyncio.sleep(self.wait)
     async def run_async(self,shared): 
         if self.successors: warnings.warn("Node won't run successors. Use AsyncFlow.")  


### PR DESCRIPTION
# Fix AsyncNode retry mechanism inconsistency

## Problem Description

The PocketFlow framework had an inconsistency between synchronous and asynchronous node retry mechanisms, causing `AttributeError` when derived classes tried to access the `cur_retry` attribute.

### Error Details

**Error Message:**

```
AttributeError: 'IdentifyComponents' object has no attribute 'cur_retry'
```

**Error Location:**

- File: `venv/lib/python3.13/site-packages/pocketflow/__init__.py`
- Method: `IdentifyComponents.exec_async()` at line 70
- Call chain: `AsyncParallelBatchNode._exec()` → `asyncio.gather()` → `AsyncNode._exec()`

### Root Cause Analysis

The issue stemmed from inconsistent retry mechanism implementations:

1. **Node._exec()** (synchronous) used `self.cur_retry` attribute:

   ```python
   for self.cur_retry in range(self.max_retries):
       try: return self.exec(prep_res)
       except Exception as e:
           if self.cur_retry==self.max_retries-1: return self.exec_fallback(prep_res,e)
   ```

2. **AsyncNode._exec()** (asynchronous) used local variable `i`:

   ```python
   for i in range(self.max_retries):
       try: return await self.exec_async(prep_res)
       except Exception as e:
           if i==self.max_retries-1: return await self.exec_fallback_async(prep_res,e)
   ```

When `IdentifyComponents` (inheriting from `AsyncParallelBatchNode` → `AsyncNode`) tried to access `self.cur_retry` in its `exec_async()` method, the attribute didn't exist because `AsyncNode._exec()` never set it.

## Solution

### Changes Made

Modified `AsyncNode._exec()` method in `pocketflow/__init__.py` to align with `Node._exec()` implementation:

**Before:**

```python
async def _exec(self,prep_res): 
    for i in range(self.max_retries):
        try: return await self.exec_async(prep_res)
        except Exception as e:
            if i==self.max_retries-1: return await self.exec_fallback_async(prep_res,e)
            if self.wait>0: await asyncio.sleep(self.wait)
```

**After:**

```python
async def _exec(self,prep_res): 
    for self.cur_retry in range(self.max_retries):
        try: return await self.exec_async(prep_res)
        except Exception as e:
            if self.cur_retry==self.max_retries-1: return await self.exec_fallback_async(prep_res,e)
            if self.wait>0: await asyncio.sleep(self.wait)
```

### Key Changes

1. **Variable Scope**: Changed from local variable `i` to instance attribute `self.cur_retry`
2. **Condition Check**: Updated condition from `i==self.max_retries-1` to `self.cur_retry==self.max_retries-1`
3. **Consistency**: Now both sync and async nodes use the same retry tracking mechanism

## Impact

### Benefits

- **Consistency**: Synchronous and asynchronous nodes now have identical retry mechanisms
- **Compatibility**: Derived classes can safely access `self.cur_retry` attribute
- **Functionality**: Async node retry functionality now works as expected
- **Backward Compatibility**: No breaking changes to existing APIs

### Testing Recommendation

```python
async def test_async_retry():
    class TestAsyncNode(AsyncNode):
        async def exec_async(self, prep_res):
            if self.cur_retry < 2:  # Fail first two attempts
                raise Exception("Test error")
            return "Success"
    
    node = TestAsyncNode(max_retries=3)
    result = await node._exec("test")
    assert result == "Success"
    print("✅ Async node retry mechanism test passed")
```

## Files Changed

- `pocketflow/__init__.py`: Modified `AsyncNode._exec()` method

## Type of Change

- **Bug Fix**: Resolves AttributeError in async node retry mechanism
- **Internal**: Framework consistency improvement
- **Non-breaking**: Maintains existing API compatibility
