### PR TITLE
Added PyYAML to requirements.txt in 'PocketFlow\cookbook\pocketflow-agent'

### DIFF
--- a/cookbook/pocketflow-agent/requirements.txt
+++ b/cookbook/pocketflow-agent/requirements.txt
@@ -1,5 +1,6 @@
 pocketflow>=0.0.1
-aiohttp>=3.8.0  # For HTTP requests
-openai>=1.0.0   # For LLM calls 
-duckduckgo-search>=7.5.2    # For web search
-requests>=2.25.1  # For HTTP requests
+duckduckgo-search>=7.5.2     # For web search
+aiohttp>=3.8.0               # For HTTP requests
+openai>=1.0.0                # For LLM calls 
+requests>=2.25.1             # For HTTP requests
+PyYAML>=6.0.2                # For YAML parsing


### PR DESCRIPTION
The application would not run due to PyYAML module not found error. After running pip install PyYAML the application would run.

Issues was from:

-'import yaml' is on line 3 of the file 'nodes.py'
-'yaml.safe_load' is called on line 62 in the file 'nodes.py'

Also organized for better readability.